### PR TITLE
patch: update labels and drafter

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,12 @@
 minor:
   - ./src/**/*.html
   - ./src/img/**
-  - ./src/scss/**/*.scss
-  - ./src/js/*.js
+  - ./src/sass/**/*.scss
+  - ./src/**/*.js
+  - ./src/**/*.njk
+  - ./src/**/*.md
+  - ./src/**/*.json
 dependencies:
   - package-lock.json
 github-action:
   - .github/**
-patch:
-  - package-lock.json
-  - CHANGELOG.md
-  - CNAME

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,15 +11,15 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: 'Maintenance'
-    labels: 
+    labels:
       - 'dependencies'
       - 'security'
-      - 'github-action'
 exclude-labels:
   - 'invalid'
   - 'Stale PR'
   - 'duplicate'
   - 'wontfix'
+  - 'github-action'
 change-template: '- #$NUMBER $TITLE (@$AUTHOR)'
 version-resolver:
   major:
@@ -37,7 +37,6 @@ version-resolver:
     labels:
       - 'dependencies'
       - 'security'
-      - 'github-action'
       - 'patch'
   default: minor
 template: |
@@ -46,11 +45,11 @@ template: |
   $CHANGES
 
   ## Contributors to this release
-  
+
   $CONTRIBUTORS
 
   ## Previous tag
-  
+
   $PREVIOUS_TAG
 no-changes-template: |
-  Confusingly, There were no changes in this release
+  Confusingly, there were no changes in this release


### PR DESCRIPTION
Update `release-drafter.yml` for random errors. Improve `labeler.yml` to account for nunjucks, markdown and json files under `/src`. Fix incorrect folder for `.scss` files.