### PR TITLE
Try to fix release update automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,17 +1,14 @@
 categories:
   - title: 'Features/Enhancements'
-    collapse-after: 5
     labels:
       - 'feature'
       - 'enhancement'
   - title: 'Fixes'
-    collapse-after: 3
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
   - title: 'Maintenance'
-    collapse-after: 2
     labels:
       - 'dependencies'
       - 'security'
@@ -40,9 +37,13 @@ version-resolver:
       - 'patch'
       - 'github-action'
   default: patch
-name-template: 'v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
-version-template: '$MAJOR.$MINOR.$PATCH$PRERELEASE'
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-template: |
+  '$MAJOR.$MINOR.$PATCH$PRERELEASE'
+  - Next Major: $NEXT_MAJOR_VERSION
+  - Next Minor: $NEXT_MINOR_VERSION
+  - Next Patch: $NEXT_PATCH_VERSION
 change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
 template: |
   ## Changes


### PR DESCRIPTION
Attempt to fix #285 by updating the `release-drafter.yml` file with simpler templating and removing of configuration options for tag-template and name-template.