### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-  www.adamjolicoeur.com


### PR DESCRIPTION
Remove `CNAME` as GitHub pages is no longer utilized.